### PR TITLE
Add initial crypto-lib Rust library

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,29 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+[package]
+name = "crypto_lib"
+version = "0.1.0"
+authors = ["Bitwise IO, Inc.", "Intel Corporation"]
+build = "build.rs"
+
+[dependencies]
+secp256k1 = "0.7.1"
+rand = "0.4.2"
+rust-crypto = "0.2.36"
+libc = "0.2"
+
+[build-dependencies]
+cc = "1.0"

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+extern crate cc;
+
+fn main() {
+    // Compile C PEM loader file
+    println!("cargo:rustc-link-lib={}={}", "dylib", "crypto");
+    cc::Build::new()
+        .file("./c/loader.c")
+        .file("./c/c11_support.c")
+        .include("./c")
+        .compile("libloader.a");
+}

--- a/rust/c/c11_support.c
+++ b/rust/c/c11_support.c
@@ -1,0 +1,67 @@
+/*
+ Copyright 2017 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------
+*/
+
+#include <errno.h>
+#include "c11_support.h"
+
+#ifndef __STDC_LIB_EXT1__
+int strncpy_s(char *dest, size_t sizeInBytes, const char *src, size_t count)
+{
+    if (count == 0 && dest == NULL && sizeInBytes == 0) {
+        return 0;
+    }
+
+    if (dest == NULL || sizeInBytes <= 0) {
+        return EINVAL;
+    }
+
+    if (count == 0) {
+        *dest = 0;
+        return 0;
+    }
+
+    if (src == NULL) {
+        *dest = 0;
+        return EINVAL;
+    }
+
+    char *p = dest;
+    size_t availableSize = sizeInBytes;
+
+    if (count == ((size_t) - 1)) {
+        while ((*p++ = *src++) != 0 && --availableSize > 0);
+    } else {
+        while ((*p++ = *src++) != 0 && --availableSize > 0 && --count > 0);
+        if (count == 0) {
+            p = NULL;
+        }
+    }
+
+    if (availableSize == 0)
+    {
+        if (count == ((size_t) - 1))
+        {
+            dest[sizeInBytes - 1] = 0;
+            return STRUNCATE;
+        }
+        *dest = 0;
+        return ERANGE;
+    }
+    return 0;
+}
+
+#endif // #ifdef __STDC_LIB_EXT1__

--- a/rust/c/c11_support.h
+++ b/rust/c/c11_support.h
@@ -1,0 +1,38 @@
+/*
+ Copyright 2017 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------
+*/
+
+#ifndef C11_SUPPORT_H
+#define C11_SUPPORT_H
+
+#include <stdlib.h>
+// If the compiler has been built with optional extensions, then we can have
+// some of the missing functions made available by defining the appropriate
+// preprocessor define before including string.h
+#ifdef __STDC_LIB_EXT1__
+    #define __STDC_WANT_LIB_EXT1__ 1
+#else
+    int strncpy_s(char *dest, size_t sizeInBytes,
+                     const char *src, size_t count);
+#endif // #ifdef __STDC_LIB_EXT1__
+
+#include <string.h>
+
+#ifndef STRUNCATE
+#define STRUNCATE 80
+#endif
+
+#endif

--- a/rust/c/loader.c
+++ b/rust/c/loader.c
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+#include "c11_support.h"
+
+#include <string.h>
+
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/engine.h>
+#include <openssl/conf.h>
+
+// Extract the private and public keys from the PEM file, using the supplied
+// password to decrypt the file if encrypted. priv_key and pub_key must point to
+// an array o at least 65 and 131 character respectively.
+int load_pem_key(char *pemstr, size_t pemstr_len, char *password,
+                 char *out_priv_key, char *out_pub_key) {
+
+  BIO *in = NULL;
+
+  BN_CTX *ctx = NULL;
+  const EC_GROUP *group;
+  EC_KEY *eckey = NULL;
+  const EC_POINT *pub_key_point = NULL;
+  const BIGNUM *priv_key = NULL, *pub_key = NULL;
+
+  char *priv_key_hex = NULL;
+  char *pub_key_hex = NULL;
+
+  in = BIO_new_mem_buf(pemstr, (int)pemstr_len);
+
+  // Read key from stream, decrypting with password if not NULL
+  if (password != NULL && strcmp("", password) != 0) {
+    // Initialize ciphers
+    ERR_load_crypto_strings ();
+    OpenSSL_add_all_algorithms ();
+
+    eckey = PEM_read_bio_ECPrivateKey(in, NULL, NULL, password);
+    if (eckey == NULL) {
+      return -1; // Failed to decrypt or decode private key
+    }
+  } else {
+    if ((eckey = PEM_read_bio_ECPrivateKey(in, NULL, NULL, NULL)) == NULL) {
+      return -1; // Failed to decode private key
+    }
+  }
+  BIO_free(in);
+
+  // Deconstruct key into big numbers
+  if ((ctx = BN_CTX_new()) == NULL) {
+    return -2; // Failed to create new big number context
+  }
+  if ((group = EC_KEY_get0_group(eckey)) == NULL) {
+    return -3; // Failed to load group
+  }
+  if ((priv_key = EC_KEY_get0_private_key(eckey)) == NULL) {
+    return -4; // Failed to load private key
+  }
+  if ((pub_key_point = EC_KEY_get0_public_key(eckey)) == NULL) {
+    return -5; // Failed to load public key point
+  }
+  pub_key = EC_POINT_point2bn(group, pub_key_point, EC_KEY_get_conv_form(eckey), NULL, ctx);
+  if (pub_key == NULL) {
+    return -6; // Failed to construct public key from point
+  }
+
+  priv_key_hex = BN_bn2hex(priv_key);
+  pub_key_hex = BN_bn2hex(pub_key);
+  strncpy_s(out_priv_key, 64 + 1, priv_key_hex, 64 + 1);
+  strncpy_s(out_pub_key, 130 + 1, pub_key_hex, 130 + 1);
+  OPENSSL_free(priv_key_hex);
+  OPENSSL_free(pub_key_hex);
+  return 0;
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+extern crate crypto;
+extern crate libc;
+extern crate rand;
+extern crate secp256k1;
+
+pub mod signing;

--- a/rust/src/signing/mod.rs
+++ b/rust/src/signing/mod.rs
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+mod pem_loader;
+pub mod secp256k1;
+
+use std::error::Error as StdError;
+use std;
+use std::borrow::Borrow;
+
+#[derive(Debug)]
+pub enum Error {
+    /// Returned when trying to create an algorithm which does not exist.
+    NoSuchAlgorithm(String),
+    /// Returned when an error occurs during deserialization of a Private or
+    /// Public key from various formats.
+    ParseError(String),
+    /// Returned when an error occurs during the signing process.
+    SigningError(Box<StdError>),
+    /// Returned when an error occurs during key generation
+    KeyGenError(String),
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::NoSuchAlgorithm(ref msg) => msg,
+            Error::ParseError(ref msg) => msg,
+            Error::SigningError(ref err) => err.description(),
+            Error::KeyGenError(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            Error::NoSuchAlgorithm(_) => None,
+            Error::ParseError(_) => None,
+            Error::SigningError(ref err) => Some(err.borrow()),
+            Error::KeyGenError(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Error::NoSuchAlgorithm(ref s) =>
+                write!(f, "NoSuchAlgorithm: {}", s),
+            Error::ParseError(ref s) =>
+                write!(f, "ParseError: {}", s),
+            Error::SigningError(ref err) =>
+                write!(f, "SigningError: {}", err.description()),
+            Error::KeyGenError(ref s) =>
+                write!(f, "KeyGenError: {}", s),
+        }
+    }
+}
+
+/// A private key instance.
+/// The underlying content is dependent on implementation.
+pub trait PrivateKey {
+    /// Returns the algorithm name used for this private key.
+    fn get_algorithm_name(&self) -> &str;
+    /// Return the private key encoded as a hex string.
+    fn as_hex(&self) -> String;
+    /// Return the private key bytes.
+    fn as_slice(&self) -> &[u8];
+}
+
+/// A public key instance.
+/// The underlying content is dependent on implementation.
+pub trait PublicKey {
+    /// Returns the algorithm name used for this public key.
+    fn get_algorithm_name(&self) -> &str;
+    /// Return the public key encoded as a hex string.
+    fn as_hex(&self) -> String;
+    /// Return the public key bytes.
+    fn as_slice(&self) -> &[u8];
+}
+
+/// A context for a cryptographic signing algorithm.
+pub trait Context {
+    /// Returns the algorithm name.
+    fn get_algorithm_name(&self) -> &str;
+    /// Sign a message
+    /// Given a private key for this algorithm, sign the given message bytes
+    /// and return a hex-encoded string of the resulting signature.
+    /// # Arguments
+    ///
+    /// * `message`- the message bytes
+    /// * `private_key` the private key
+    ///
+    /// # Returns
+    ///
+    /// * `signature` - The signature in a hex-encoded string
+    fn sign(&self, message: &[u8], key: &PrivateKey) -> Result<String, Error>;
+
+    /// Verifies that the signature of a message was produced with the
+    /// associated public key.
+    /// # Arguments
+    ///
+    /// * `signature` - the hex-encoded signature
+    /// * `message` - the message bytes
+    /// * `public_key` - the public key to use for verification
+    ///
+    /// # Returns
+    ///
+    /// * `boolean` - True if the public key is associated with the signature for that method,
+    ///            False otherwise
+    fn verify(&self, signature: &str, message: &[u8], key: &PublicKey) -> Result<bool, Error>;
+
+    /// Produce the public key for the given private key.
+    /// # Arguments
+    ///
+    /// `private_key` - a private key
+    ///
+    /// # Returns
+    /// * `public_key` - the public key for the given private key
+    fn get_public_key(&self, private_key: &PrivateKey) -> Result<Box<PublicKey>, Error>;
+
+    ///Generates a new random PrivateKey using this context.
+    /// # Returns
+    ///
+    /// * `private_key` - a random private key
+    fn new_random_private_key(&self) -> Result<Box<PrivateKey>, Error>;
+}
+
+pub fn create_context(algorithm_name: &str) -> Result<Box<Context>, Error> {
+    match algorithm_name {
+        "secp256k1" => Ok(Box::new(secp256k1::Secp256k1Context::new())),
+        _ => Err(Error::NoSuchAlgorithm(format!("no such algorithm: {}", algorithm_name)))
+    }
+}
+/// Factory for generating signers.
+pub struct CryptoFactory<'a> {
+    context: &'a Context
+}
+
+impl<'a> CryptoFactory<'a> {
+
+    /// Constructs a CryptoFactory.
+    /// # Arguments
+    ///
+    /// * `context` - a cryptographic context
+    pub fn new(context: &'a Context) -> Self {
+        CryptoFactory{ context: context }
+    }
+
+    /// Returns the context associated with this factory
+    ///
+    /// # Returns
+    ///
+    /// * `context` - a cryptographic context
+    pub fn get_context(&self) -> &Context {
+        return self.context
+    }
+
+    /// Create a new signer for the given private key.
+    ///
+    /// # Arguments
+    ///
+    /// `private_key` - a private key
+    ///
+    /// # Returns
+    ///
+    /// * `signer` - a signer instance
+    pub fn new_signer(&self, key: &'a PrivateKey) -> Signer {
+        Signer::new(self.context, key)
+    }
+}
+
+/// A convenient wrapper of Context and PrivateKey
+pub struct Signer<'a> {
+    context: &'a Context,
+    key: &'a PrivateKey
+}
+
+impl<'a> Signer<'a> {
+    /// Constructs a new Signer
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - a cryptographic context
+    /// * `private_key` - private key
+    pub fn new(context: &'a Context, key: &'a PrivateKey) -> Self {
+        Signer {
+            context: context,
+            key: key
+        }
+    }
+
+    /// Signs the given message.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - the message bytes
+    ///
+    /// # Returns
+    ///
+    /// * `signature` - the signature in a hex-encoded string
+    pub fn sign(&self, message: &[u8]) -> Result<String, Error> {
+        self.context.sign(message, self.key)
+    }
+
+    /// Return the public key for this Signer instance.
+    ///
+    /// # Returns
+    ///
+    /// * `public_key` - the public key instance
+    pub fn get_public_key(&self) -> Result<Box<PublicKey>, Error> {
+        self.context.get_public_key(self.key)
+    }
+}
+
+#[cfg(test)]
+mod signing_test {
+    use super::create_context;
+
+    #[test]
+    fn no_such_algorithm() {
+        let result = create_context("invalid");
+        assert!(result.is_err())
+    }
+}

--- a/rust/src/signing/pem_loader.rs
+++ b/rust/src/signing/pem_loader.rs
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+mod ffi {
+    extern crate libc;
+    use self::libc::{size_t, c_int, c_char};
+
+    #[link(name = "loader")]
+    extern {
+        pub fn load_pem_key(pemstr: *mut c_char, pemstr_len: size_t, password: *mut c_char,
+                            out_priv_key: *mut c_char, out_pub_key: *mut c_char) -> c_int;
+    }
+
+}
+use std::ffi::CString;
+use super::Error;
+
+
+pub fn load_pem_key(pemstr: &str, password: &str) -> Result<(String, String), Error> {
+    let c_pemstr = CString::new(pemstr).unwrap();
+    let c_password = CString::new(password).unwrap();
+    let pemstr_len = pemstr.len();
+    let mut c_out_priv_key = CString::new("-----------------------------------------------------------------").unwrap();
+    let mut c_out_pub_key = CString::new("-----------------------------------------------------------------------------------------------------------------------------------").unwrap();
+
+    let err_num = unsafe {
+        let c_ptr_pemstr = c_pemstr.into_raw();
+        let c_ptr_password = c_password.into_raw();
+        let c_ptr_out_priv_key = c_out_priv_key.into_raw();
+        let c_ptr_out_pub_key = c_out_pub_key.into_raw();
+
+        let err_num = ffi::load_pem_key(c_ptr_pemstr, pemstr_len, c_ptr_password,
+            c_ptr_out_priv_key, c_ptr_out_pub_key);
+
+        // Need to take back ownership of all pointers to avoid memory leak
+        let _ = CString::from_raw(c_ptr_pemstr);
+        let _ = CString::from_raw(c_ptr_password);
+
+        // Need to return these
+        c_out_priv_key = CString::from_raw(c_ptr_out_priv_key);
+        c_out_pub_key = CString::from_raw(c_ptr_out_pub_key);
+
+        err_num
+    };
+
+    match err_num {
+        -1 => Err(Error::ParseError(String::from("Failed to decrypt or decode private key"))),
+        -2 => Err(Error::ParseError(String::from("Failed to create new big number context"))),
+        -3 => Err(Error::ParseError(String::from("Failed to load group"))),
+        -4 => Err(Error::ParseError(String::from("Failed to load private key"))),
+        -5 => Err(Error::ParseError(String::from("Failed to load public key point"))),
+        -6 => Err(Error::ParseError(String::from("Failed to construct public key from point"))),
+        _ => {
+            let priv_key = c_out_priv_key.into_string().map_err(|_|
+                Error::ParseError(String::from("FFI Error")))?;
+            let pub_key = c_out_pub_key.into_string().map_err(|_|
+                Error::ParseError(String::from("FFI Error")))?;
+            Ok((priv_key, pub_key))
+        }
+    }
+}

--- a/rust/src/signing/secp256k1.rs
+++ b/rust/src/signing/secp256k1.rs
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+use crypto::digest::Digest;
+use crypto::sha2::Sha256;
+
+use rand::Rng;
+use rand::os::OsRng;
+use secp256k1;
+
+use signing::PrivateKey;
+use signing::PublicKey;
+use signing::Context;
+use signing::Error;
+use signing::pem_loader::load_pem_key;
+
+impl From<secp256k1::Error> for Error {
+    fn from(e: secp256k1::Error) -> Self {
+        Error::SigningError(Box::new(e))
+    }
+}
+
+pub struct Secp256k1PrivateKey {
+    private: Vec<u8>
+}
+
+impl Secp256k1PrivateKey {
+    pub fn from_hex(s: &str) -> Result<Self, Error> {
+        hex_str_to_bytes(s).map(|key_bytes| Secp256k1PrivateKey{ private: key_bytes })
+    }
+
+    pub fn from_pem(s: &str) -> Result<Self, Error> {
+        let (priv_key_str, _) = load_pem_key(s, "")?;
+        Self::from_hex(&priv_key_str)
+    }
+
+    pub fn from_pem_with_password(s: &str, pw: &str) -> Result<Self, Error> {
+        let (priv_key_str, _) = load_pem_key(s, pw)?;
+        Self::from_hex(&priv_key_str)
+    }
+}
+
+impl PrivateKey for Secp256k1PrivateKey {
+    fn get_algorithm_name(&self) -> &str {
+        "secp256k1"
+    }
+
+    fn as_hex(&self) -> String {
+        bytes_to_hex_str(&self.private)
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        return &self.private;
+    }
+}
+
+pub struct Secp256k1PublicKey {
+    public: Vec<u8>
+}
+
+impl Secp256k1PublicKey {
+    pub fn from_hex(s: &str) -> Result<Self, Error> {
+        hex_str_to_bytes(s).map(|key_bytes| Secp256k1PublicKey{ public: key_bytes })
+    }
+}
+
+impl PublicKey for Secp256k1PublicKey {
+    fn get_algorithm_name(&self) -> &str {
+        "secp256k1"
+    }
+
+    fn as_hex(&self) -> String {
+        bytes_to_hex_str(&self.public)
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        return &self.public;
+    }
+}
+
+pub struct Secp256k1Context {
+    context: secp256k1::Secp256k1
+}
+
+impl Secp256k1Context {
+    pub fn new() -> Self {
+        Secp256k1Context{
+            context: secp256k1::Secp256k1::new()
+        }
+    }
+}
+
+impl Context for Secp256k1Context {
+    fn get_algorithm_name(&self) -> &str {
+        "secp256k1"
+    }
+
+    fn sign(&self, message: &[u8], key: &PrivateKey) -> Result<String, Error> {
+        let mut sha = Sha256::new();
+        sha.input(message);
+        let hash: &mut [u8] = & mut [0; 32];
+        sha.result(hash);
+
+        let sk = secp256k1::key::SecretKey::from_slice(&self.context, key.as_slice())?;
+        let sig = self.context.sign(&secp256k1::Message::from_slice(hash)?, &sk)?;
+        let compact = sig.serialize_compact(&self.context);
+        Ok(compact.iter()
+                  .map(|b| format!("{:02x}", b))
+                  .collect::<Vec<_>>()
+                  .join(""))
+    }
+
+    fn verify(&self, signature: &str, message: &[u8], key: &PublicKey) -> Result<bool, Error> {
+        let mut sha = Sha256::new();
+        sha.input(message);
+        let hash: &mut [u8] = & mut [0; 32];
+        sha.result(hash);
+
+        let result = self.context.verify(
+            &secp256k1::Message::from_slice(hash)?,
+            &secp256k1::Signature::from_compact(&self.context, &hex_str_to_bytes(&signature)?)?,
+            &secp256k1::key::PublicKey::from_slice(&self.context, key.as_slice())?);
+        match result {
+            Ok(()) => Ok(true),
+            Err(secp256k1::Error::IncorrectSignature) => Ok(false),
+            Err(err) => Err(Error::from(err))
+        }
+    }
+
+    fn get_public_key(&self, private_key: &PrivateKey) -> Result<Box<PublicKey>, Error> {
+        let sk = secp256k1::key::SecretKey::from_slice(&self.context, private_key.as_slice())?;
+        let result = Secp256k1PublicKey::from_hex(
+            bytes_to_hex_str(
+                &secp256k1::key::PublicKey::from_secret_key(
+                    &self.context, &sk)?.serialize_vec(&self.context, true)).as_str());
+        match result {
+            Err(err) => Err(err),
+            Ok(pk) => Ok(Box::new(pk))
+        }
+    }
+
+    fn new_random_private_key(&self) -> Result<Box<PrivateKey>, Error> {
+        let mut rng = OsRng::new().map_err(|err| Error::KeyGenError(format!("{}", err)))?;
+        let mut key = [0u8; secp256k1::constants::SECRET_KEY_SIZE];
+        rng.fill_bytes(&mut key);
+        Ok(Box::new(Secp256k1PrivateKey { private: Vec::from(&key[..]) }))
+    }
+}
+
+fn hex_str_to_bytes(s: &str) -> Result<Vec<u8>, Error> {
+    for (i, ch) in s.chars().enumerate() {
+        if !ch.is_digit(16) {
+            return Err(Error::ParseError(format!("invalid character position {}", i)));
+        }
+    }
+
+    let input: Vec<_> = s.chars().collect();
+
+    let decoded: Vec<u8> = input.chunks(2).map(|chunk| {
+        ((chunk[0].to_digit(16).unwrap() << 4) |
+        (chunk[1].to_digit(16).unwrap())) as u8
+    }).collect();
+
+    return Ok(decoded);
+}
+
+fn bytes_to_hex_str(b: &[u8]) -> String {
+    b.iter()
+     .map(|b| format!("{:02x}", b))
+     .collect::<Vec<_>>()
+     .join("")
+}
+
+#[cfg(test)]
+mod secp256k1_test {
+    use super::Secp256k1PrivateKey;
+    use super::Secp256k1PublicKey;
+    use super::super::CryptoFactory;
+    use super::super::PrivateKey;
+    use super::super::PublicKey;
+    use super::super::create_context;
+
+    static KEY1_PRIV_HEX: &'static str = "2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088";
+    static KEY1_PUB_HEX: &'static str = "026a2c795a9776f75464aa3bda3534c3154a6e91b357b1181d3f515110f84b67c5";
+
+    static KEY2_PRIV_HEX: &'static str = "51b845c2cdde22fe646148f0b51eaf5feec8c82ee921d5e0cbe7619f3bb9c62d";
+    static KEY2_PUB_HEX: &'static str = "039c20a66b4ec7995391dbec1d8bb0e2c6e6fd63cd259ed5b877cb4ea98858cf6d";
+
+    static MSG1: &'static str = "test";
+    static MSG1_KEY1_SIG: &'static str = "5195115d9be2547b720ee74c23dd841842875db6eae1f5da8605b050a49e702b4aa83be72ab7e3cb20f17c657011b49f4c8632be2745ba4de79e6aa05da57b35";
+
+    static MSG2: &'static str = "test2";
+    static MSG2_KEY2_SIG: &'static str = "d589c7b1fa5f8a4c5a389de80ae9582c2f7f2a5e21bab5450b670214e5b1c1235e9eb8102fd0ca690a8b42e2c406a682bd57f6daf6e142e5fa4b2c26ef40a490";
+
+    #[test]
+    fn hex_key() {
+        let priv_key = Secp256k1PrivateKey::from_hex(KEY1_PRIV_HEX).unwrap();
+        assert_eq!(priv_key.get_algorithm_name(), "secp256k1");
+        assert_eq!(priv_key.as_hex(), KEY1_PRIV_HEX);
+
+        let pub_key = Secp256k1PublicKey::from_hex(KEY1_PUB_HEX).unwrap();
+        assert_eq!(pub_key.get_algorithm_name(), "secp256k1");
+        assert_eq!(pub_key.as_hex(), KEY1_PUB_HEX);
+    }
+
+    #[test]
+    fn priv_to_public_key() {
+        let context = create_context("secp256k1").unwrap();
+        assert_eq!(context.get_algorithm_name(), "secp256k1");
+
+        let priv_key1 = Secp256k1PrivateKey::from_hex(KEY1_PRIV_HEX).unwrap();
+        assert_eq!(priv_key1.get_algorithm_name(), "secp256k1");
+        assert_eq!(priv_key1.as_hex(), KEY1_PRIV_HEX);
+
+        let public_key1 = context.get_public_key(&priv_key1).unwrap();
+        assert_eq!(public_key1.as_hex(), KEY1_PUB_HEX);
+
+        let priv_key2 = Secp256k1PrivateKey::from_hex(KEY2_PRIV_HEX).unwrap();
+        assert_eq!(priv_key2.get_algorithm_name(), "secp256k1");
+        assert_eq!(priv_key2.as_hex(), KEY2_PRIV_HEX);
+
+        let public_key2 = context.get_public_key(&priv_key2).unwrap();
+        assert_eq!(public_key2.as_hex(), KEY2_PUB_HEX);
+    }
+
+    #[test]
+    fn check_invalid_digit() {
+        let mut priv_chars: Vec<char> = KEY1_PRIV_HEX.chars().collect();
+        priv_chars[3] = 'i';
+        let priv_result = Secp256k1PrivateKey::from_hex(
+            priv_chars.into_iter().collect::<String>().as_str());
+        assert!(priv_result.is_err());
+
+        let mut pub_chars: Vec<char> = KEY1_PUB_HEX.chars().collect();
+        pub_chars[3] = 'i';
+        let result = Secp256k1PublicKey::from_hex(
+            pub_chars.into_iter().collect::<String>().as_str());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn single_key_signing() {
+        let context = create_context("secp256k1").unwrap();
+        assert_eq!(context.get_algorithm_name(), "secp256k1");
+
+        let factory = CryptoFactory::new(&*context);
+        assert_eq!(factory.get_context().get_algorithm_name(), "secp256k1");
+
+        let priv_key = Secp256k1PrivateKey::from_hex(KEY1_PRIV_HEX).unwrap();
+        assert_eq!(priv_key.get_algorithm_name(), "secp256k1");
+        assert_eq!(priv_key.as_hex(), KEY1_PRIV_HEX);
+
+        let signer = factory.new_signer(&priv_key);
+        let signature = signer.sign(&String::from(MSG1).into_bytes()).unwrap();
+        assert_eq!(signature, MSG1_KEY1_SIG);
+    }
+
+    #[test]
+    fn many_key_signing() {
+        let context = create_context("secp256k1").unwrap();
+        assert_eq!(context.get_algorithm_name(), "secp256k1");
+
+        let priv_key1 = Secp256k1PrivateKey::from_hex(KEY1_PRIV_HEX).unwrap();
+        assert_eq!(priv_key1.get_algorithm_name(), "secp256k1");
+        assert_eq!(priv_key1.as_hex(), KEY1_PRIV_HEX);
+
+        let priv_key2 = Secp256k1PrivateKey::from_hex(KEY2_PRIV_HEX).unwrap();
+        assert_eq!(priv_key2.get_algorithm_name(), "secp256k1");
+        assert_eq!(priv_key2.as_hex(), KEY2_PRIV_HEX);
+
+        let signature = context.sign(
+            &String::from(MSG1).into_bytes(),
+            &priv_key1).unwrap();
+        assert_eq!(signature, MSG1_KEY1_SIG);
+
+        let signature = context.sign(
+            &String::from(MSG2).into_bytes(),
+            &priv_key2).unwrap();
+        assert_eq!(signature, MSG2_KEY2_SIG);
+    }
+
+    #[test]
+    fn verification() {
+        let context = create_context("secp256k1").unwrap();
+        assert_eq!(context.get_algorithm_name(), "secp256k1");
+
+        let pub_key1 = Secp256k1PublicKey::from_hex(KEY1_PUB_HEX).unwrap();
+        assert_eq!(pub_key1.get_algorithm_name(), "secp256k1");
+        assert_eq!(pub_key1.as_hex(), KEY1_PUB_HEX);
+
+        let result = context.verify(MSG1_KEY1_SIG,
+                                    &String::from(MSG1).into_bytes(),
+                                    &pub_key1);
+        assert_eq!(result.unwrap(), true);
+    }
+
+    #[test]
+    fn verification_error() {
+        let context = create_context("secp256k1").unwrap();
+        assert_eq!(context.get_algorithm_name(), "secp256k1");
+
+        let pub_key1 = Secp256k1PublicKey::from_hex(KEY1_PUB_HEX).unwrap();
+        assert_eq!(pub_key1.get_algorithm_name(), "secp256k1");
+        assert_eq!(pub_key1.as_hex(), KEY1_PUB_HEX);
+
+        // This signature doesn't match for MSG1/KEY1
+        let result = context.verify(MSG2_KEY2_SIG,
+                                    &String::from(MSG1).into_bytes(),
+                                    &pub_key1);
+        assert_eq!(result.unwrap(), false);
+    }
+}


### PR DESCRIPTION
This was copied from Sawtooth's Rust SDK (sawtooth-core/sdk/rust). It
provides a signing API which is intended to be pluggable. Currently it
provides a secp256k1 wrapper implementation.

The tests (run with cargo test) provide usage examples. Sawtooth
applications (such as the workload generators) also provide good example
code of this API in use.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>