### PR TITLE
fixed bn.to_hex() function using local mutable var

### DIFF
--- a/libhl-crypto/src/pair/amcl.rs
+++ b/libhl-crypto/src/pair/amcl.rs
@@ -470,7 +470,8 @@ impl GroupOrderElement {
     }
 
     pub fn to_string(&self) -> Result<String, HLCryptoError> {
-        Ok(self.bn.to_hex())
+        let mut bn = self.bn;
+        Ok(bn.to_hex())
     }
 
     pub fn from_string(str: &str) -> Result<GroupOrderElement, HLCryptoError> {
@@ -513,7 +514,8 @@ impl GroupOrderElement {
 
 impl Debug for GroupOrderElement {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "GroupOrderElement {{ bn: {} }}", self.bn.to_hex())
+        let mut bn = self.bn;
+        write!(f, "GroupOrderElement {{ bn: {} }}", bn.to_hex())
     }
 }
 


### PR DESCRIPTION
with rustc 1.34.0-nightly (146aa60f3 2019-02-18), bn is immutable and won't be converted to string.  Added local variable to fix error. 